### PR TITLE
feat(client): 1.6.0 => bulk-export lakehouse fields + new ExportType …

### DIFF
--- a/YulsnApiClient/Models/V1/YulsnBulkExport.cs
+++ b/YulsnApiClient/Models/V1/YulsnBulkExport.cs
@@ -38,7 +38,8 @@ namespace YulsnApiClient.Models.V1
         public bool UseCompression { get; set; }
 
         /// <summary>
-        /// Output format. Defaults to Csv. Parquet is not supported for ContactExport-scoped exports.
+        /// Output format. If omitted or <c>null</c>, the server defaults to Csv.
+        /// Parquet is not supported for ContactExport-scoped exports.
         /// </summary>
         public ExportFormat? Format { get; set; }
     }

--- a/YulsnApiClient/Models/V1/YulsnBulkExport.cs
+++ b/YulsnApiClient/Models/V1/YulsnBulkExport.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -14,12 +14,33 @@ namespace YulsnApiClient.Models.V1
         public string RowDelimiter { get; set; }
         public DateTimeOffset? CreatedDateTimeFrom { get; set; }
         public DateTimeOffset? CreatedDateTimeTo { get; set; }
+
+        /// <summary>
+        /// Optional LastModified-based window for incremental sync. Only honored by exporters whose
+        /// underlying table has a real LastModified column (Contacts, PointSums, PushTokens, SmsReceivers).
+        /// For tables that only have Created, use CreatedDateTimeFrom/To instead.
+        /// </summary>
+        public DateTimeOffset? LastModifiedFrom { get; set; }
+        public DateTimeOffset? LastModifiedTo { get; set; }
+
+        /// <summary>
+        /// Optional integer-id watermark for insert-only exports. Exporters that honor it add
+        /// <c>AND Id &gt; @LastId</c>. Use this for tables like ContactEvents / Email2Interactions
+        /// where a strict per-row cursor is preferable to a date window.
+        /// </summary>
+        public int? LastId { get; set; }
+
         public string ItemType { get; set; }
         public int? SegmentId { get; set; }
         public List<string> Fields { get; set; }
         public string SuffixFileName { get; set; }
         public string TimeZoneId { get; set; }
         public bool UseCompression { get; set; }
+
+        /// <summary>
+        /// Output format. Defaults to Csv. Parquet is not supported for ContactExport-scoped exports.
+        /// </summary>
+        public ExportFormat? Format { get; set; }
     }
 
     public class YulsnExportItem
@@ -31,7 +52,7 @@ namespace YulsnApiClient.Models.V1
         public DateTimeOffset? CreatedDateTimeFrom { get; set; }
         public DateTimeOffset? CreatedDateTimeTo { get; set; }
         public string ItemType { get; set; }
-        public int RowCount { get; set; }
+        public int? RowCount { get; set; }
         public int? SegmentId { get; set; }
         public string Right { get; set; }
         public string TimeZoneId { get; set; }
@@ -46,6 +67,28 @@ namespace YulsnApiClient.Models.V1
         Orders,
         OrderLines,
         Events,
-        EmailCampaignClicks
+        EmailCampaignClicks,
+        ContactCompanies,
+        VoucherCodes,
+        PermissionLogs,
+        Email2Dispatches,
+        Email2Receivers,
+        Email2Interactions,
+        Email2Bounces,
+        SmsDispatches,
+        SmsReceivers,
+        PushDispatches,
+        PushReceivers,
+        PushTokens,
+        ContactPermissionSources,
+        VoucherGroups,
+        Vouchers,
+        VoucherAssignments
+    }
+
+    public enum ExportFormat
+    {
+        Csv = 0,
+        Parquet = 1
     }
 }

--- a/YulsnApiClient/Models/V1/YulsnBulkExport.cs
+++ b/YulsnApiClient/Models/V1/YulsnBulkExport.cs
@@ -25,7 +25,7 @@ namespace YulsnApiClient.Models.V1
 
         /// <summary>
         /// Optional integer-id watermark for insert-only exports. Exporters that honor it add
-        /// <c>AND Id &gt; @LastId</c>. Use this for tables like ContactEvents / Email2Interactions
+        /// <c>AND Id &gt; @LastId</c>. Use this for export types like Events / Email2Interactions
         /// where a strict per-row cursor is preferable to a date window.
         /// </summary>
         public int? LastId { get; set; }

--- a/YulsnApiClient/YulsnApiClient.csproj
+++ b/YulsnApiClient/YulsnApiClient.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <Authors>Yulsn ApS</Authors>
     <Company>Yulsn ApS</Company>
     <Product>Api Client for Yulsn</Product>


### PR DESCRIPTION
…values

Brings the BulkExport client up to date with the server-side additions from PR 505 (Loyaltii):

YulsnExportSettings:
- LastModifiedFrom / LastModifiedTo (DateTimeOffset?) — independent LastModified window for incremental sync.
- LastId (int?) — strict insert-only id cursor.
- Format (ExportFormat?) — Csv / Parquet.

ExportType enum: adds 16 new values to match server-side
- ContactCompanies, VoucherCodes, PermissionLogs
- Email2Dispatches, Email2Receivers, Email2Interactions, Email2Bounces
- SmsDispatches, SmsReceivers
- PushDispatches, PushReceivers, PushTokens
- ContactPermissionSources
- VoucherGroups, Vouchers, VoucherAssignments

ExportFormat enum added (Csv = 0, Parquet = 1).

YulsnExportItem.RowCount changed from int to int? to match server.

YulsnClient.BulkExport.cs needs no method changes — server only exposes Get and Post, and the new fields flow through via the request DTO.